### PR TITLE
Json decode error instead of HTTPException

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,14 @@ Changed
 ^^^^^^^
 * Renamed ``NEWS`` to ``CHANGELOG``.
 
+[v0.1.5a] - Unreleased (Anyday)
+------------------------------
+
+Added
+^^^^^
+* Updated kraken connection to raise error in case it doesnt receive 20x status code. 
+
+
 [v0.1.4] - 2017-03-27 (Monday)
 ------------------------------
   

--- a/krakenex/connection.py
+++ b/krakenex/connection.py
@@ -78,4 +78,7 @@ class Connection(object):
         self.conn.request('POST', url, data, headers)
         response = self.conn.getresponse()
 
+        if response.status not in (200, 201, 202):
+            raise http.client.HTTPException
+
         return response.read().decode()

--- a/krakenex/connection.py
+++ b/krakenex/connection.py
@@ -79,6 +79,6 @@ class Connection(object):
         response = self.conn.getresponse()
 
         if response.status not in (200, 201, 202):
-            raise http.client.HTTPException
+            raise http.client.HTTPException(response.status)
 
         return response.read().decode()


### PR DESCRIPTION
In case kraken has connection problems and it doesnt return 20x status code, we process the code and got Json decode error.

This is confusing as there is a problem with connection to Kraken not with the response it returned. Therefore I have updated connection to raise a proper exception. This way in application developers can handle kraken connection issues gracefully.