### PR TITLE
Add proxy support in API definition

### DIFF
--- a/krakenex/api.py
+++ b/krakenex/api.py
@@ -53,7 +53,7 @@ class API(object):
        pair, the effects are undefined.
 
     """
-    def __init__(self, key='', secret='', conn=None):
+    def __init__(self, key='', secret='', conn=None, proxy=''):
         """ Create an object with authentication information.
 
         :param key: key required to make queries to the API
@@ -70,6 +70,7 @@ class API(object):
         self.uri = 'https://api.kraken.com'
         self.apiversion = '0'
         self.conn = conn
+        self.proxy = proxy
         return
 
     def load_key(self, path):
@@ -140,7 +141,7 @@ class API(object):
 
         if conn is None:
             if self.conn is None:
-                self.conn = connection.Connection()
+                self.conn = connection.Connection(proxy=self.proxy)
             conn = self.conn
 
         if headers is None:

--- a/krakenex/connection.py
+++ b/krakenex/connection.py
@@ -32,13 +32,15 @@ class Connection(object):
 
     """
 
-    def __init__(self, uri='api.kraken.com', timeout=30):
+    def __init__(self, uri='api.kraken.com', timeout=30, proxy=''):
         """ Create an object for reusable connections.
 
         :param uri: URI to connect to
         :type uri: str
         :param timeout: blocking operations' timeout (in seconds)
         :type timeout: int
+        :param proxy: URL of the proxy
+        :type proxy: str
         :returns: None
 
         """
@@ -46,7 +48,11 @@ class Connection(object):
             'User-Agent': 'krakenex/' + version.__version__ +
             ' (+' + version.__url__ + ')'
         }
-        self.conn = http.client.HTTPSConnection(uri, timeout=timeout)
+        if proxy == '':
+            self.conn = http.client.HTTPSConnection(uri, timeout = timeout)
+        else:
+            self.conn = http.client.HTTPSConnection(proxy, timeout=timeout)
+            self.conn.set_tunnel(uri)
         return
 
     def close(self):


### PR DESCRIPTION
I've added the support of proxy, if you want to use a proxy you can specify it in the API definition as shown below:
```
import krakenex
k = krakenex.API(proxy='my.proxy.net')
```