### PR TITLE
Connection:  Implement a mechanism to retry failed HTTP requests for certain status_codes 

### DIFF
--- a/krakenex/api.py
+++ b/krakenex/api.py
@@ -27,6 +27,7 @@ import urllib.parse
 import hashlib
 import hmac
 import base64
+import logging
 
 from . import version
 
@@ -109,20 +110,34 @@ class API(object):
         :raises: :py:exc:`requests.HTTPError`: if response status not successful
 
         """
+        logger = logging.getLogger()
+
         if data is None:
             data = {}
         if headers is None:
             headers = {}
-
+        
         url = self.uri + urlpath
 
-        self.response = self.session.post(url, data = data, headers = headers)
+        max_retries =  3
+        attempt = 1
 
-        if self.response.status_code not in (200, 201, 202):
-            self.response.raise_for_status()
-
-        return self.response.json()
-
+        # Retries mechanism for certain HTTP codes. 
+        # Kraken is behind CloudFlare which adds to network requests instability during peaks
+        # Careful! Sometimes service returns error code but actuallu executes a request
+        # needs investigation if this can cause a multiple buys/sells (don't think so as there is nonce in each request )
+        while attempt<=max_retries:
+            self.response = self.session.post(url, data = data, headers = headers)
+                
+            if self.response.status_code in (200, 201, 202):
+                return self.response.json()
+            elif self.response.status_code in (504, 520) and attempt<max_retries:
+                logger.debug("HTTP Error. Status Code %d. Attempting to reconnect (attempt: %d)", self.response.status_code, attempt)
+                attempt = attempt + 1
+                continue
+            else:
+                # Raises stored HTTPError, if one occurred.
+                self.response.raise_for_status()
 
     def query_public(self, method, data=None):
         """ Performs an API query that does not require a valid key/secret pair.


### PR DESCRIPTION
Fixes #66 
During peak times large amount of http requests are failing without a specific response from Kraken server. These are  intermittent problems with CloudFlare/Kraken and for some of returned http codes it should be safe to retry an operation. 
Max number of retries is configurable via bad_http_connection_retries attribute.  As each request has a unique nonce which is checked on a server, it should prevent execution of several identical requests if they get to a server despite a failed status_code.