### PR TITLE
Python 2 compatibility and native imports

### DIFF
--- a/krakenex/api.py
+++ b/krakenex/api.py
@@ -23,12 +23,17 @@ import requests
 import time
 
 # private query signing
-import urllib.parse
 import hashlib
 import hmac
 import base64
 
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    from urllib import urlencode
+
 from . import version
+
 
 class API(object):
     """ Maintains a single session between this machine and Kraken.
@@ -116,13 +121,12 @@ class API(object):
 
         url = self.uri + urlpath
 
-        self.response = self.session.post(url, data = data, headers = headers)
+        self.response = self.session.post(url, data=data, headers=headers)
 
         if self.response.status_code not in (200, 201, 202):
             self.response.raise_for_status()
 
         return self.response.json()
-
 
     def query_public(self, method, data=None):
         """ Performs an API query that does not require a valid key/secret pair.
@@ -174,7 +178,7 @@ class API(object):
         :returns: an always-increasing unsigned integer (up to 64 bits wide)
 
         """
-        return int(1000*time.time())
+        return int(1000 * time.time())
 
     def _sign(self, data, urlpath):
         """ Sign request data according to Kraken's scheme.
@@ -185,7 +189,7 @@ class API(object):
         :type urlpath: str
         :returns: signature digest
         """
-        postdata = urllib.parse.urlencode(data)
+        postdata = urlencode(data)
 
         # Unicode-objects must be encoded before hashing
         encoded = (str(data['nonce']) + postdata).encode()

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,13 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import os.path
 from distutils.core import setup
+from krakenex.version import __url__, __version__
 
-exec(open('./krakenex/version.py').read())
 
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
 
 setup(name='krakenex',
       version=__version__,
@@ -15,11 +16,10 @@ setup(name='krakenex',
       author='Noel Maersk',
       author_email='veox+packages+spamremove@veox.pw',
       url=__url__,
-      install_requires=[
-          'requests>=2.18.2,<3'
-      ],
+      install_requires=read("requirements.txt").splitlines(),
       packages=['krakenex'],
       classifiers=[
+          'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 3',
-      ],
+      ]
 )


### PR DESCRIPTION
Make the krakenex working with Python 2 by changing the way urlparse is imported into api.py, also added version 2 on setup.py classifiers.
Used native import for __version__ and __url__ and read() to specify the dependencies.

Hope it can help, thanks for your work with krakenex!