### PR TITLE
Optional timeout

### DIFF
--- a/krakenex/api.py
+++ b/krakenex/api.py
@@ -148,13 +148,16 @@ class API(object):
 
         return self._query(urlpath, data, timeout = timeout)
 
-    def query_private(self, method, data=None):
+    def query_private(self, method, data=None, timeout=None):
         """ Performs an API query that requires a valid key/secret pair.
 
         :param method: API method name
         :type method: str
         :param data: (optional) API request parameters
         :type data: dict
+        :param timeout: (optional) if not None, a `requests.HTTPError` will be 
+        thrown after `timeout` seconds if a response has not been received
+        :type timeout: number
         :returns: :py:meth:`requests.Response.json`-deserialised Python object
 
         """
@@ -173,7 +176,7 @@ class API(object):
             'API-Sign': self._sign(data, urlpath)
         }
 
-        return self._query(urlpath, data, headers)
+        return self._query(urlpath, data, headers, timeout = timeout)
 
     def _nonce(self):
         """ Nonce counter.

--- a/krakenex/api.py
+++ b/krakenex/api.py
@@ -92,7 +92,7 @@ class API(object):
             self.secret = f.readline().strip()
         return
 
-    def _query(self, urlpath, data, headers=None):
+    def _query(self, urlpath, data, headers=None, timeout=None):
         """ Low-level query handling.
 
         .. note::
@@ -105,6 +105,9 @@ class API(object):
         :type data: dict
         :param headers: (optional) HTTPS headers
         :type headers: dict
+        :param timeout: (optional) if not None, a `requests.HTTPError` will be 
+        thrown after `timeout` seconds if a response has not been received
+        :type timeout: number
         :returns: :py:meth:`requests.Response.json`-deserialised Python object
         :raises: :py:exc:`requests.HTTPError`: if response status not successful
 
@@ -116,7 +119,8 @@ class API(object):
 
         url = self.uri + urlpath
 
-        self.response = self.session.post(url, data = data, headers = headers)
+        self.response = self.session.post(url, data = data, headers = headers, 
+                                          timeout = timeout)
 
         if self.response.status_code not in (200, 201, 202):
             self.response.raise_for_status()

--- a/krakenex/api.py
+++ b/krakenex/api.py
@@ -128,13 +128,16 @@ class API(object):
         return self.response.json()
 
 
-    def query_public(self, method, data=None):
+    def query_public(self, method, data=None, timeout=None):
         """ Performs an API query that does not require a valid key/secret pair.
 
         :param method: API method name
         :type method: str
         :param data: (optional) API request parameters
         :type data: dict
+        :param timeout: (optional) if not None, a `requests.HTTPError` will be 
+        thrown after `timeout` seconds if a response has not been received
+        :type timeout: number
         :returns: :py:meth:`requests.Response.json`-deserialised Python object
 
         """
@@ -143,7 +146,7 @@ class API(object):
 
         urlpath = '/' + self.apiversion + '/public/' + method
 
-        return self._query(urlpath, data)
+        return self._query(urlpath, data, timeout = timeout)
 
     def query_private(self, method, data=None):
         """ Performs an API query that requires a valid key/secret pair.


### PR DESCRIPTION
This is proposed solution to #67. The newly added timeout parameter is None by default, so the default behavior remains unchanged, but gives the option to add a timeout to those who wish to use one.

Originally I had added a `timeout` variable to the `API` class, but after thinking about it for awhile, I believe making the timeout an argument on `public_query` and `private_query` methods is a better solution, and this PR adopts that stance. Having to specify the timeout on each request is a little bit more verbose, but makes it easier to specify timeouts independently and dynamically for each endpoint.

